### PR TITLE
Added request node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/ritterim/sparkles",
   "dependencies": {
     "hapi": "^7.2.0",
+    "request": "^2.47.0",
     "rpi-gpio": "^0.5.0"
   }
 }


### PR DESCRIPTION
This will allow us to ping TeamCity at the following url:

``` text
http://{build-server}/httpAuth/app/rest/builds?locator=branch:default:any,running:true
```

This was my initial spike. Note that I have **moment** as another package dependency.

``` javascript
var request = require('request');
var moment = require('moment');
var interval = 1000; /* ms */

var pingTeamcityBuildQueue = function() {

  var options = {
    url: 'http://######/httpAuth/app/rest/builds?locator=branch:default:any,running:true',
    method: 'GET',
    auth: {
      'user': '****',
      'pass': '****'
    },
    json: true,
    headers : {
      'Accept' : 'application/json',
      'Content-Type' : 'application/json'
    }
  };

  console.log('waiting for teamcity...');
  request.get(options, function (error, response, body) {
    if (error) {
      console.log(error);
    } else {
      console.log("current # of builds " + "(" + moment().format("dddd, MMMM Do YYYY, h:mm:ss a") + ") : " + body.count );
      toggleLights(body.count);
    }
    setTimeout(pingTeamcityBuildQueue, interval);
  });
}

pingTeamcityBuildQueue();
```
