### PR TITLE
Add pass fail light-feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var Hapi = require('hapi');
 var buildingLightManager = require('./buildingLightManager');
 var twitterLightManager = require('./twitterLightManager');
+var passFailLightManager = require('./passFailLightManager');
 
 var server = new Hapi.Server(process.env.PORT);
 
@@ -19,17 +20,28 @@ var config = {
             pin: process.env.LIGHTS_TWITTER_PIN,
             provider: process.env.LIGHTS_TWITTER_PROVIDER
         },
+        pass: {
+            pin: process.env.LIGHTS_PASS_PIN,
+            provider: process.env.LIGHTS_PASS_PROVIDER
+        },
+        fail: {
+            pin: process.env.LIGHTS_FAIL_PIN,
+            provider: process.env.LIGHTS_FAIL_PROVIDER,
+            exclusionList: process.env.LIGHTS_FAIL_EXCLUSION_LIST.split(',')
+        }
     },
     teamcity: {
         user: process.env.TC_USER,
         password: process.env.TC_PASSWORD,
         queryInterval: process.env.QUERY_INTERVAL,
-        baseUri: process.env.TC_URI
+        baseUri: process.env.TC_URI,
+        buildStatusQueryInterval: process.env.TC_BUILD_STATUS_QUERY_INTERVAL
     }
 };
 
 var building = new buildingLightManager(config);
 var twitter = new twitterLightManager(config);
+var passFail = new passFailLightManager(config);
 
 server.route({
     method: 'GET',
@@ -43,5 +55,6 @@ server.start(function () {
     console.log('Sparkles running at: ', server.info.uri);
     building.start();
     twitter.start();
+    passFail.start();
 });
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/ritterim/sparkles",
   "dependencies": {
+    "cheerio": "^0.17.0",
     "hapi": "^7.2.0",
     "moment": "^2.8.3",
     "request": "^2.47.0",

--- a/passFailLightManager.js
+++ b/passFailLightManager.js
@@ -1,0 +1,103 @@
+var lightManager = require('./lightManager');
+var moment = require('moment');
+var request = require('request');
+var cheerio = require('cheerio');
+
+var passFailLightManager = function(options) {
+    if (typeof options === 'undefined') {
+        options = {
+            lights: {
+                pass: {},
+                fail: {
+                    exclusionList: []
+                }
+            },
+            teamcity: {
+                baseUri: '',
+                password: '',
+                buildStatusQueryInterval: '',
+                user: ''
+            }
+        };
+    }
+
+    var passLight = new lightManager(options.lights.pass);
+    var failLight = new lightManager(options.lights.fail);    
+    var togglePassFailLightsInterval = null;
+    var togglePassLight = true;
+
+    var scrapeTeamCity = function() {
+        var teamCityOptions = {
+            url: 'http://' + options.teamcity.baseUri,
+            method: 'GET',
+            auth: {
+                'user': options.teamcity.user,
+                'pass': options.teamcity.password
+            }
+        };
+
+        request.get(teamCityOptions, function(error, response, body) {
+            clearInterval(togglePassFailLightsInterval);
+
+            togglePassFailLightsInterval = setInterval(function() {
+                togglePassFailLights(togglePassLight);
+                togglePassLight = !togglePassLight;
+            }, 200);
+            
+            var $ = cheerio.load(body);
+            var failuresExist = false;
+            
+            $('td.projectName').each(function() {
+                var $this = $(this);
+                var projectTitle = $this.find('a').text();
+                var projectStatus = $this.find('.handle').attr('title');
+
+                failuresExist = projectStatus.indexOf('fail') !== -1 && !isProjectInExclusionList(projectTitle, options.lights.fail.exclusionList) ? true : failuresExist;
+                    
+                console.log('%s (%s)', projectTitle, projectStatus);
+            });
+
+            setTimeout(function() {
+                if (failuresExist) {
+                    passLight.turnOff();
+                    failLight.turnOn();
+                }
+                else {
+                    failLight.turnOff();
+                    passLight.turnOn();
+                }
+
+                clearInterval(togglePassFailLightsInterval);
+            }, 1000);
+            
+            setTimeout(scrapeTeamCity, options.teamcity.buildStatusQueryInterval);
+        });
+    }
+
+    function isProjectInExclusionList(project, exclusionList) {
+        for (var i = 0; i < exclusionList.length; i++) {
+            if (exclusionList[i].indexOf(project) !== -1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    
+    function togglePassFailLights(togglePass) {
+        if (togglePass) {
+            failLight.turnOff();
+            passLight.turnOn();
+        }
+        else {
+            passLight.turnOff();
+            failLight.turnOn();
+        }
+    }
+
+    this.start = function() {
+        scrapeTeamCity();
+    }
+};
+
+module.exports = passFailLightManager;


### PR DESCRIPTION
First iteration scrapes TeamCity home page to get list of projects and parses to determine whether they have any failing builds. During the beginning of each query, the pass/fail-light combination will toggle back and forth. Then, depending on the scraping outcome, either the pass or fail light will remain on – until the next query.

Note: Would have preferred to use their API, but did not see any way to get active branch-builds and **_only**_ retrieve latest builds from each project.
