### PR TITLE
Fix default light provider

### DIFF
--- a/fakeLightProvider.js
+++ b/fakeLightProvider.js
@@ -1,4 +1,6 @@
 var fakeLightProvider = function(config) {
+    var ID = 'fakeLightProvider';
+
     var pin = typeof config.get('pin') === 'undefined' ? 7 : config.get('pin');
     var self = this;
     var blinkTimeout = null;
@@ -13,6 +15,10 @@ var fakeLightProvider = function(config) {
             self.turnOff();
         }, interval);
     };
+
+    this.getId = function() {
+        return ID;
+    }
 
     this.turnOff = function() {
         console.log('Turning pin %s off', pin);

--- a/lightManager.js
+++ b/lightManager.js
@@ -3,16 +3,20 @@ var raspiLightProvider = require('./raspiLightProvider');
 
 var lightManager = function(config) {
     var provider = typeof config.get('provider') === 'string'
-        ? (config.get('provider') === 'raspiLightProvider' ? new raspiLightProvider(config) : new fakeLightProvider(config))
+        ? (config.get('provider') === 'fakeLightProvider' ? new fakeLightProvider(config) : new raspiLightProvider(config))
         : config.get('provider');
 
     this.blink = function(interval) {
         provider.blink(interval);
     };
 
+    this.getProvider = function() {
+        return provider;
+    };
+
     this.turnOff = function() {
         provider.turnOff();
-    }
+    };
 
     this.turnOn = function() {
         provider.turnOn();

--- a/raspiLightProvider.js
+++ b/raspiLightProvider.js
@@ -1,8 +1,10 @@
 var gpio = require('rpi-gpio');
 
 var raspiLightProvider = function(config) {
+    var ID = 'raspiLightProvider';
     var OFF = true;
     var ON = false;
+
     var pin = config.get('pin') || 7;
     var self = this;
     var blinkTimeout = null;
@@ -20,6 +22,10 @@ var raspiLightProvider = function(config) {
         blinkTimeout = setTimeout(function() {
             self.turnOff();
         }, interval);
+    };
+
+    this.getId = function() {
+        return ID;
     };
 
     this.turnOff = function() {

--- a/tests/lightManagerTests.js
+++ b/tests/lightManagerTests.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var gpio = require('rpi-gpio');
 var sinon = require('sinon');
 var sut = require('./../lightManager');
 
@@ -8,6 +9,32 @@ var Provider = function() {
 };
 
 suite('LightManager', function() {
+    suite('#constructor()', function() {
+        test('should use fake provider if provided', function() {
+            var provider = 'fakeLightProvider';
+
+            var result = new sut({
+                get: function() {
+                    return provider;
+                }
+            });
+
+            assert.equal('fakeLightProvider', result.getProvider().getId());
+        });
+
+        test('should use raspi provider if none provided', function() {
+            var spy = sinon.stub(gpio, 'setup');
+
+            var result = new sut({
+                get: function() {
+                    return '';
+                }
+            });
+
+            assert.equal('raspiLightProvider', result.getProvider().getId());
+        });
+    });
+
     suite('#turnOff()', function() {
         test('should call provider\'s turnOff function', function() {
             var provider = new Provider();


### PR DESCRIPTION
Previous logic was backwards in terms of forcing the config. to define the raspi provider.
The expected behavior is to force the fake provider for dev. purposes.
