### PR TITLE
Update default light pin assignment

### DIFF
--- a/fakeLightProvider.js
+++ b/fakeLightProvider.js
@@ -22,6 +22,10 @@ var fakeLightProvider = function(config) {
         return ID;
     }
 
+    this.getPin = function() {
+        return pin;
+    };
+
     this.turnOff = function() {
         console.log('Turning pin %s off', pin);
     };

--- a/fakeLightProvider.js
+++ b/fakeLightProvider.js
@@ -1,7 +1,9 @@
 var fakeLightProvider = function(config) {
     var ID = 'fakeLightProvider';
 
-    var pin = typeof config.get('pin') === 'undefined' ? 7 : config.get('pin');
+    var pin = config.get('pin');
+    pin = pin === null ? 7 : pin;
+
     var self = this;
     var blinkTimeout = null;
 

--- a/raspiLightProvider.js
+++ b/raspiLightProvider.js
@@ -5,7 +5,9 @@ var raspiLightProvider = function(config) {
     var OFF = true;
     var ON = false;
 
-    var pin = config.get('pin') || 7;
+    var pin = config.get('pin');
+    pin = pin === null ? 7 : pin;
+
     var self = this;
     var blinkTimeout = null;
 

--- a/raspiLightProvider.js
+++ b/raspiLightProvider.js
@@ -30,6 +30,10 @@ var raspiLightProvider = function(config) {
         return ID;
     };
 
+    this.getPin = function() {
+        return pin;
+    };
+
     this.turnOff = function() {
         gpio.write(pin, OFF);
     };

--- a/tests/fakeLightProviderTests.js
+++ b/tests/fakeLightProviderTests.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var sut = require('./../fakeLightProvider');
+
+suite('FakeLightProvider', function() {
+    suite('#constructor()', function() {
+        test('should use pin config. if provided', function() {
+            var result = new sut({
+                get: function() {
+                    return '0';
+                }
+            });
+
+            assert.equal('0', result.getPin());
+        });
+
+        test('should use default pin numbering if no value provided', function() {
+            var result = new sut({
+                get: function() {
+                    return null;
+                }
+            });
+
+            assert.equal('7', result.getPin());
+        });
+    });
+});

--- a/tests/raspiLightProviderTests.js
+++ b/tests/raspiLightProviderTests.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var sut = require('./../raspiLightProvider');
+
+suite('RaspiLightProvider', function() {
+    suite('#constructor()', function() {
+        test('should use pin config. if provided', function() {
+            var result = new sut({
+                get: function() {
+                    return '0';
+                }
+            });
+
+            assert.equal('0', result.getPin());
+        });
+
+        test('should use default pin numbering if no value provided', function() {
+            var result = new sut({
+                get: function() {
+                    return null;
+                }
+            });
+
+            assert.equal('7', result.getPin());
+        });
+    });
+});


### PR DESCRIPTION
Fix default pin assignment within light providers.
Previous behavior was designed prior to having a config. library.
New behavior does not follow where the pin-property would be undefined. Undefined pin-values are now null.
